### PR TITLE
Fix module imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@ pip install -r requirements.txt
 python orchestrator/workflow_orchestrator.py
 ```
 
+The script automatically adjusts `sys.path` so it can be executed directly
+from the project root on any platform.
+
 3. Optionally start the Streamlit dashboard:
 
 ```bash
 streamlit run ui/streamlit_dashboard.py
 ```
+
+Like the orchestrator script, the dashboard modifies `sys.path` at runtime, so
+you can launch it from the project root without setting `PYTHONPATH`.
 
 ## Project Structure
 

--- a/orchestrator/workflow_orchestrator.py
+++ b/orchestrator/workflow_orchestrator.py
@@ -1,7 +1,15 @@
 import os
+import sys
 import asyncio
+from pathlib import Path
 import yaml
 from typing import Any, Dict
+
+# Ensure project root is on sys.path so "agents" package can be imported when
+# running this file directly (e.g. ``python orchestrator/workflow_orchestrator.py``).
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from agents.design.layout_agent import LayoutAgent
 from agents.design.logo_agent import LogoAgent

--- a/ui/streamlit_dashboard.py
+++ b/ui/streamlit_dashboard.py
@@ -1,5 +1,14 @@
+import sys
+from pathlib import Path
 import streamlit as st
 import json
+
+# Ensure project root is on sys.path so Streamlit can find the orchestrator
+# and agents packages when running ``streamlit run ui/streamlit_dashboard.py``.
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 from orchestrator.workflow_orchestrator import run
 
 st.title("PixelMind Labs Dashboard")


### PR DESCRIPTION
## Summary
- adjust `sys.path` so workflow_orchestrator and Streamlit dashboard work when executed as scripts
- document running these scripts from the project root

## Testing
- `pip install -r requirements.txt`
- `python orchestrator/workflow_orchestrator.py` *(fails: FileNotFoundError on dummy logo but no import errors)*
- `streamlit run ui/streamlit_dashboard.py` *(started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_685fdc05e68483208307c656c7b9311d