### PR TITLE
Fix timestamp filenames for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ This interface visualizes workflow graphs using React Flow.
 - `data/feedback_db.json` – feedback data store
 - `ui/` – dashboard scaffolding
 
+All agent logs and workflow outputs are stored under the `history/` directory
+using timestamped filenames. Filenames are generated with a helper that replaces
+colons with dashes so the logs work on both Windows and Linux.
+
 ## Testing
 
 You can manually test the workflow by running the orchestrator script. This will

--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -1,22 +1,22 @@
 import json
-import os
-from datetime import datetime
 from typing import Any, Dict
+
+from tools.file_utils import ensure_history_dir, safe_timestamp, HISTORY_DIR
 
 class BaseAgent:
     """Base class for all agents with logging and history support."""
 
     name: str = "BaseAgent"
-    history_dir: str = "history"
+    history_dir: str = str(HISTORY_DIR)
 
     def __init__(self, name: str):
         self.name = name
-        os.makedirs(os.path.join(self.history_dir, self.name), exist_ok=True)
+        ensure_history_dir(self.name)
 
     def log(self, data: Dict[str, Any]) -> None:
         """Log JSON data to a history file with timestamp."""
-        timestamp = datetime.utcnow().isoformat()
-        path = os.path.join(self.history_dir, self.name, f"{timestamp}.json")
+        timestamp = safe_timestamp()
+        path = HISTORY_DIR / self.name / f"{timestamp}.json"
         with open(path, "w") as f:
             json.dump(data, f, indent=2)
 

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,0 +1,14 @@
+import re
+import unittest
+from tools.file_utils import safe_timestamp
+
+
+class TestSafeTimestamp(unittest.TestCase):
+    def test_format(self):
+        ts = safe_timestamp()
+        self.assertNotIn(":", ts)
+        self.assertRegex(ts, r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d{6}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/file_utils.py
+++ b/tools/file_utils.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from pathlib import Path
+
+HISTORY_DIR = Path("history")
+
+
+def safe_timestamp() -> str:
+    """Return timestamp string safe for filenames."""
+    return datetime.now().strftime("%Y-%m-%d_%H-%M-%S-%f")
+
+
+def ensure_history_dir(agent_name: str) -> Path:
+    """Ensure history directory exists for the given agent and return its path."""
+    path = HISTORY_DIR / agent_name
+    path.mkdir(parents=True, exist_ok=True)
+    return path


### PR DESCRIPTION
## Summary
- provide `safe_timestamp` helper in `file_utils`
- log agent history with new helper
- document cross-platform timestamp file naming
- add unit test for the timestamp helper

## Testing
- `python -m unittest tests.test_file_utils -v`
- `python test_all.py`

------
https://chatgpt.com/codex/tasks/task_e_6862b249b7808320b97a3137c0403f4e