### PR TITLE
Fix missing logo file handling

### DIFF
--- a/agents/design/logo_agent.py
+++ b/agents/design/logo_agent.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict
+import logging
 from agents.base_agent import BaseAgent
 from tools.logo_processor import process_logo
 
@@ -11,6 +12,9 @@ class LogoAgent(BaseAgent):
     def execute(self, task: Dict[str, Any]) -> Dict[str, Any]:
         """Simplify logo and return path to processed asset."""
         input_path = task.get("logo_path")
+        if not input_path:
+            logging.warning("No logo_path provided; generating placeholder.")
+            input_path = "dummy_logo.png"
         output_path = process_logo(input_path)
         response = {"agent": self.name, "processed_logo": output_path}
         self.log({"task": task, "response": response})

--- a/tools/logo_processor.py
+++ b/tools/logo_processor.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import logging
 import cv2
 import numpy as np
 from rembg import remove
@@ -9,7 +10,7 @@ def process_logo(input_path: str) -> str:
     output_file = input_file.with_name(input_file.stem + "_processed.png")
 
     if not input_file.exists():
-        # create a dummy logo file if missing
+        logging.warning("Logo file '%s' not found. Creating placeholder.", input_path)
         dummy = np.zeros((10, 10, 3), dtype=np.uint8)
         cv2.imwrite(str(input_file), dummy)
 


### PR DESCRIPTION
## Summary
- warn and supply placeholder if no logo path is provided in `LogoAgent`
- warn and generate placeholder file in `process_logo`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fbae828c8320b5d4f97fea673901