### PR TITLE
Fix React Flow integration

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,15 +1,31 @@
-import { useNodesState, useEdgesState } from 'reactflow';
-import Head from 'next/head';
+import { useCallback } from 'react';
 import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import {
+  useNodesState,
+  useEdgesState,
+  addEdge,
+  type Connection,
+  type Edge,
+  type Node,
+} from 'reactflow';
 import { WorkflowProvider } from '../state/workflowContext';
+import 'reactflow/dist/style.css';
 
-const ReactFlow = dynamic(() => import('reactflow').then(m => m.ReactFlow), {
-  ssr: false,
-});
+const ReactFlow = dynamic(() => import('reactflow'), { ssr: false });
+
+const initialNodes: Node[] = [
+  { id: '1', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
+];
+
+const initialEdges: Edge[] = [];
 
 export default function Home() {
-  const [nodes, setNodes, onNodesChange] = useNodesState([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const onConnect = useCallback((params: Connection) =>
+    setEdges((eds) => addEdge(params, eds)),
+  []);
 
   return (
     <WorkflowProvider>
@@ -19,7 +35,14 @@ export default function Home() {
       <div className="flex h-screen">
         <aside className="w-60 bg-gray-100 p-4">Sidebar</aside>
         <main className="flex-1 relative">
-          <ReactFlow nodes={nodes} edges={edges} onNodesChange={onNodesChange} onEdgesChange={onEdgesChange} />
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            className="h-full"
+          />
         </main>
       </div>
     </WorkflowProvider>


### PR DESCRIPTION
## Summary
- integrate ReactFlow with Next.js correctly
- import default stylesheet from `reactflow`
- define initial nodes and edges
- handle connections to update edges

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863a088f1588320be66df25b7c3cfbb