### PR TITLE
Add health endpoint

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/health")
+async def health():
+    return {"workflows": "ok", "keys": "ok"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
-from .api import routes_workflows, routes_keys
+from .api import routes_workflows, routes_keys, health
 
 app = FastAPI(title="PixelMind Labs API")
 
 app.include_router(routes_workflows.router, prefix="/api/workflows", tags=["workflows"])
 app.include_router(routes_keys.router, prefix="/api/keys", tags=["keys"])
+app.include_router(health.router, tags=["health"])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 pydantic
 python-dotenv
 openai
+opencv-python
+numpy
+rembg

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 pydantic
 python-dotenv
 openai
+opencv-python
+numpy
+rembg


### PR DESCRIPTION
## Summary
- add health router for simple status checks
- include health router in FastAPI app
- update Python requirements with all dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863ad9619908320b8a2e54fff3e4e70