### PR TITLE
Add OpenAI status to health check

### DIFF
--- a/backend/app/api/routes_health.py
+++ b/backend/app/api/routes_health.py
@@ -1,11 +1,23 @@
 from fastapi import APIRouter
+import openai
+from ..core.settings import get_settings
 
 router = APIRouter()
 
 @router.get('/health')
 def health_check():
-    """Simple health check returning status of key API endpoints."""
+    """Return status information for key API endpoints and integrations."""
+    settings = get_settings()
+    openai_status = "missing_key"
+    if settings.OPENAI_API_KEY:
+        try:
+            openai.api_key = settings.OPENAI_API_KEY
+            openai.Model.list()
+            openai_status = "ok"
+        except Exception:
+            openai_status = "error"
     return {
         "workflows": "ok",
-        "keys": "ok"
+        "keys": "ok",
+        "openai": openai_status,
     }

--- a/frontend/src/components/ApiStatus.tsx
+++ b/frontend/src/components/ApiStatus.tsx
@@ -38,16 +38,20 @@ export default function ApiStatus() {
     <div>
       <h3 className="font-bold mb-2">API Status</h3>
       <ul className="space-y-1">
-        {Object.entries(data).map(([key, value]) => (
-          <li key={key} className="flex items-center space-x-2">
-            <span
-              className={`h-2 w-2 rounded-full ${
-                value === 'ok' ? 'bg-green-500' : 'bg-red-500'
-              }`}
-            />
-            <span>{key}</span>
-          </li>
-        ))}
+        {Object.entries(data).map(([key, value]) => {
+          const color =
+            value === 'ok'
+              ? 'bg-green-500'
+              : value === 'missing_key'
+              ? 'bg-yellow-500'
+              : 'bg-red-500';
+          return (
+            <li key={key} className="flex items-center space-x-2">
+              <span className={`h-2 w-2 rounded-full ${color}`} />
+              <span>{key}</span>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- extend `/api/health` to check for OpenAI integration
- show missing API keys in the UI with a yellow indicator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863afd1392483208ba6c1ca82973a91