### PR TITLE
Implement API key management UI and endpoints

### DIFF
--- a/backend/app/api/routes_keys.py
+++ b/backend/app/api/routes_keys.py
@@ -1,16 +1,75 @@
 from fastapi import APIRouter
+from pydantic import BaseModel
+from datetime import datetime
 import openai
-from ..core.settings import get_settings
 
 router = APIRouter()
 
+# In-memory storage for API keys and their status
+api_keys: dict[str, dict] = {}
+
+class KeyItem(BaseModel):
+    provider: str
+    key: str
+
+class ProviderItem(BaseModel):
+    provider: str
+
+
+def _validate_openai(key: str) -> str:
+    try:
+        openai.api_key = key
+        openai.Model.list()
+        return "ok"
+    except Exception:
+        return "invalid"
+
+@router.post('/add')
+def add_key(item: KeyItem):
+    api_keys[item.provider] = {
+        "key": item.key,
+        "status": "unknown",
+        "last_checked": None,
+    }
+    return {"status": "added"}
+
+@router.post('/update')
+def update_key(item: KeyItem):
+    api_keys[item.provider] = {
+        "key": item.key,
+        "status": "unknown",
+        "last_checked": None,
+    }
+    return {"status": "updated"}
+
+@router.post('/delete')
+def delete_key(item: ProviderItem):
+    api_keys.pop(item.provider, None)
+    return {"status": "deleted"}
+
 @router.post('/validate')
-def validate(provider: str, key: str):
-    if provider.lower() == 'openai':
-        try:
-            openai.api_key = key
-            openai.Model.list()
-            return {"status": "valid"}
-        except Exception as e:
-            return {"status": "error", "detail": str(e)}
-    return {"status": "error", "detail": "unknown provider"}
+def validate_key(item: ProviderItem | KeyItem):
+    stored = api_keys.get(item.provider)
+    key = getattr(item, 'key', None) or (stored and stored.get('key'))
+    if not key:
+        return {"status": "missing"}
+    status = "unknown"
+    if item.provider.lower() == 'openai':
+        status = _validate_openai(key)
+    api_keys[item.provider] = {
+        "key": key,
+        "status": status,
+        "last_checked": datetime.utcnow().isoformat(),
+    }
+    return {"status": status}
+
+@router.get('/list')
+def list_keys():
+    return [
+        {
+            "provider": p,
+            "status": v.get("status", "unknown"),
+            "last_checked": v.get("last_checked"),
+        }
+        for p, v in api_keys.items()
+    ]

--- a/frontend/src/components/ApiConnections.tsx
+++ b/frontend/src/components/ApiConnections.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react';
+
+interface KeyInfo {
+  provider: string;
+  status: string;
+  last_checked?: string | null;
+}
+
+const PROVIDERS = ['openai', 'anthropic', 'mistral'];
+
+export default function ApiConnections() {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  const [keys, setKeys] = useState<KeyInfo[]>([]);
+  const [provider, setProvider] = useState<string>('openai');
+  const [keyInput, setKeyInput] = useState('');
+  const [editing, setEditing] = useState<string | null>(null);
+  const [message, setMessage] = useState('');
+
+  const fetchKeys = async () => {
+    try {
+      const res = await fetch(`${baseUrl}/api/keys/list`);
+      if (res.ok) {
+        const data = await res.json();
+        setKeys(data);
+      }
+    } catch {
+      // ignore errors
+    }
+  };
+
+  useEffect(() => {
+    fetchKeys();
+  }, [baseUrl]);
+
+  const saveKey = async () => {
+    const url = `${baseUrl}/api/keys/${editing ? 'update' : 'add'}`;
+    const body = { provider, key: keyInput };
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        sessionStorage.setItem(`key_${provider}`, keyInput);
+        setKeyInput('');
+        setEditing(null);
+        setMessage('Saved');
+        fetchKeys();
+      } else {
+        setMessage('Error saving');
+      }
+    } catch {
+      setMessage('Error saving');
+    }
+  };
+
+  const deleteKey = async (prov: string) => {
+    try {
+      await fetch(`${baseUrl}/api/keys/delete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: prov }),
+      });
+      sessionStorage.removeItem(`key_${prov}`);
+      fetchKeys();
+    } catch {
+      // ignore
+    }
+  };
+
+  const validateKey = async (prov: string) => {
+    const stored = sessionStorage.getItem(`key_${prov}`);
+    try {
+      await fetch(`${baseUrl}/api/keys/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: prov, key: stored }),
+      });
+      fetchKeys();
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div>
+      <h3 className="font-bold mb-2">API Connections</h3>
+      <ul className="space-y-1">
+        {keys.map((k) => (
+          <li key={k.provider} className="flex items-center space-x-2">
+            <span className="w-24 capitalize">{k.provider}</span>
+            <span>{k.status}</span>
+            {k.last_checked && (
+              <span className="text-xs text-gray-500">{k.last_checked}</span>
+            )}
+            <button
+              className="text-blue-500 text-sm"
+              onClick={() => {
+                setProvider(k.provider);
+                setEditing(k.provider);
+              }}
+            >
+              Edit
+            </button>
+            <button
+              className="text-red-500 text-sm"
+              onClick={() => deleteKey(k.provider)}
+            >
+              Delete
+            </button>
+            <button
+              className="text-green-500 text-sm"
+              onClick={() => validateKey(k.provider)}
+            >
+              Test Key
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-4 space-y-2">
+        <h4 className="font-semibold">
+          {editing ? `Edit ${editing} Key` : 'Add API Key'}
+        </h4>
+        <div className="flex space-x-2">
+          <select
+            className="border p-1"
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+          >
+            {PROVIDERS.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+          <input
+            type="password"
+            className="border p-1 flex-1"
+            placeholder="API Key"
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+          />
+          <button
+            onClick={saveKey}
+            className="bg-blue-500 text-white px-2 rounded"
+          >
+            Save
+          </button>
+        </div>
+        {message && <div className="text-sm text-gray-600">{message}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
+import Link from 'next/link';
 import download from 'downloadjs';
 import ApiStatus from '../components/ApiStatus';
 import {
@@ -108,6 +109,9 @@ function FlowBuilder() {
           >
             Export
           </button>
+          <Link href="/settings" className="block bg-white border rounded text-center px-2 py-1">
+            Settings
+          </Link>
           <ApiStatus />
         </aside>
         <main className="flex-1 relative" ref={reactFlowWrapper}>

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import ApiConnections from '../components/ApiConnections';
+
+export default function Settings() {
+  return (
+    <div className="p-4">
+      <Head>
+        <title>Settings - PixelMind Labs</title>
+      </Head>
+      <Link href="/" className="text-blue-500">&larr; Back</Link>
+      <h1 className="text-xl font-bold mb-4">Settings</h1>
+      <ApiConnections />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create in-memory API key CRUD and validation routes in FastAPI
- add Settings link in React sidebar
- implement `ApiConnections` component to manage API keys without revealing values
- add Settings page displaying API Connections panel

## Testing
- `python -m compileall backend/app`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b69658a0832094b39fc7b351395b