### PR TITLE
Add endpoint testing UI and CORS

### DIFF
--- a/backend/app/api/routes_nodes.py
+++ b/backend/app/api/routes_nodes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Body
 from pydantic import BaseModel
 import openai
 
@@ -31,12 +31,13 @@ validators = {
     "binance": _validate_stub,
 }
 
-@router.post('/test/{provider}')
-def test_node(provider: str, item: KeyTest):
+@router.api_route('/test/{provider}', methods=['GET', 'POST'])
+def test_node(provider: str, item: KeyTest | None = Body(default=None)):
     validator = validators.get(provider.lower())
     if not validator:
         return {"status": "error", "error": "unsupported provider"}
-    result = validator(item.key or "")
+    key = item.key if item else ""
+    result = validator(key)
     if result == "success":
         return {"status": "success"}
     return {"status": "error", "error": result.replace('error: ', '')}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from .api import (
     routes_workflows,
     routes_keys,
@@ -8,6 +9,13 @@ from .api import (
 )
 
 app = FastAPI(title="PixelMind Labs API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(routes_workflows.router, prefix="/api/workflows", tags=["workflows"])
 app.include_router(routes_keys.router, prefix="/api/keys", tags=["keys"])

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import ApiConnections from '../components/ApiConnections';
 import NodeSettings from '../components/NodeSettings';
+import ApiStatus from '../components/ApiStatus';
 import { useState } from 'react';
 
 export default function Settings() {
@@ -13,6 +14,9 @@ export default function Settings() {
       </Head>
       <Link href="/" className="text-blue-500">&larr; Back</Link>
       <h1 className="text-xl font-bold mb-4">Settings</h1>
+      <div className="mb-4">
+        <ApiStatus />
+      </div>
       <div className="flex">
         <aside className="w-40 mr-4 space-y-2">
           <button


### PR DESCRIPTION
## Summary
- support CORS on FastAPI
- allow GET requests for `/api/test/{provider}`
- show API health in settings page
- provide UI to test endpoints in `NodeSettings`

## Testing
- `npm --prefix frontend run lint` *(fails: `next` not found)*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68642a60cce48320a71cbc829795a6ac