### PR TITLE
Add node connectivity checks and dark mode flow fixes

### DIFF
--- a/frontend/src/components/NodeSettings.tsx
+++ b/frontend/src/components/NodeSettings.tsx
@@ -16,70 +16,88 @@ const NODES = [
 export default function NodeSettings() {
   const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
   const [statuses, setStatuses] = useState<Record<string, string>>({});
-  const [messages, setMessages] = useState<Record<string, string>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [inputs, setInputs] = useState<Record<string, string>>({});
 
   const fetchStatus = async (node: string) => {
     try {
       const res = await fetch(`${baseUrl}/api/test/${node}`);
       const data = await res.json();
-      if (res.ok && data.status === 'success') {
+      if (res.ok && data.ok) {
         setStatuses((s) => ({ ...s, [node]: 'ok' }));
         setErrors((e) => ({ ...e, [node]: '' }));
       } else {
         setStatuses((s) => ({ ...s, [node]: 'error' }));
         setErrors((e) => ({ ...e, [node]: data.error || 'Error' }));
       }
-      setMessages((m) => ({ ...m, [node]: JSON.stringify(data, null, 2) }));
     } catch (e: any) {
       setStatuses((s) => ({ ...s, [node]: 'error' }));
       setErrors((er) => ({ ...er, [node]: e.message }));
-      setMessages((m) => ({ ...m, [node]: '' }));
+    }
+  };
+
+  const loadKeys = async () => {
+    try {
+      const res = await fetch(`${baseUrl}/api/keys/list`);
+      if (res.ok) {
+        const data = await res.json();
+        const vals: Record<string, string> = {};
+        data.forEach((d: any) => {
+          const stored = sessionStorage.getItem(`key_${d.provider}`) || '';
+          vals[d.provider] = stored;
+        });
+        setInputs(vals);
+      }
+    } catch {
+      // ignore
     }
   };
 
   useEffect(() => {
+    loadKeys();
     NODES.forEach((n) => fetchStatus(n));
   }, [baseUrl]);
+
+  const handleInputChange = (node: string, value: string) => {
+    setInputs((i) => ({ ...i, [node]: value }));
+    sessionStorage.setItem(`key_${node}`, value);
+  };
 
   return (
     <div>
       <h3 className="font-bold mb-2">Nodes</h3>
       <ul className="space-y-2">
         {NODES.map((n) => (
-          <li key={n}>
-            <details className="border rounded p-2 dark:border-gray-600">
-              <summary className="cursor-pointer capitalize flex items-center">
+          <li key={n} className="border rounded p-2 dark:border-gray-600">
+            <div className="flex items-center mb-2">
+              <span className="capitalize flex-1">{n}</span>
+              {statuses[n] && (
                 <span
-                  className={`h-2 w-2 rounded-full mr-2 ${
-                    statuses[n] === 'ok'
-                      ? 'bg-green-500'
-                      : statuses[n] === 'error'
-                      ? 'bg-red-500'
-                      : 'bg-gray-400'
+                  className={`text-xs px-2 py-0.5 rounded ${
+                    statuses[n] === 'ok' ? 'bg-green-600' : 'bg-red-600'
                   }`}
-                />
-                {n}
-              </summary>
-              <div className="mt-2 space-y-2">
-                <button
-                  className="bg-blue-500 text-white px-2 py-1 rounded"
-                  onClick={() => fetchStatus(n)}
                 >
-                  Test Endpoint
-                </button>
-                {messages[n] && (
-                  <pre className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
-                    {messages[n]}
-                  </pre>
-                )}
-                {errors[n] && (
-                  <pre className="text-sm text-red-500 whitespace-pre-wrap">
-                    {errors[n]}
-                  </pre>
-                )}
+                  {statuses[n] === 'ok' ? '✔️ Success' : '❌ Failed'}
+                </span>
+              )}
+            </div>
+            <input
+              type="password"
+              className="border p-1 mb-2 w-full dark:border-gray-600 dark:bg-gray-700"
+              value={inputs[n] || ''}
+              onChange={(e) => handleInputChange(n, e.target.value)}
+            />
+            <button
+              className="bg-blue-500 text-white px-2 py-1 rounded"
+              onClick={() => fetchStatus(n)}
+            >
+              Test Key
+            </button>
+            {errors[n] && (
+              <div className="text-sm text-red-500 mt-1 whitespace-pre-wrap">
+                {errors[n]}
               </div>
-            </details>
+            )}
           </li>
         ))}
       </ul>

--- a/frontend/src/components/nodes/InputNode.tsx
+++ b/frontend/src/components/nodes/InputNode.tsx
@@ -9,6 +9,7 @@ export default function InputNode({ data }: NodeProps<InputNodeData>) {
   return (
     <div className="bg-white dark:bg-gray-700 border dark:border-gray-600 rounded shadow-sm px-2 py-1 text-sm dark:text-white">
       <div className="font-bold text-center">{data.title || 'Input'}</div>
+      <Handle type="target" position={Position.Left} id="in" />
       <Handle type="source" position={Position.Right} id="out" />
     </div>
   );

--- a/frontend/src/components/nodes/LLMNode.tsx
+++ b/frontend/src/components/nodes/LLMNode.tsx
@@ -13,6 +13,7 @@ export default function LLMNode({ data }: NodeProps<LLMNodeData>) {
   return (
     <div className="bg-white dark:bg-gray-700 border dark:border-gray-600 rounded shadow-sm px-2 py-1 text-sm dark:text-white">
       <div className="font-bold text-center">{data.title || 'LLM'}</div>
+      <Handle type="target" position={Position.Left} id="in" />
       <Handle type="source" position={Position.Right} id="out" />
     </div>
   );

--- a/frontend/src/components/nodes/OutputNode.tsx
+++ b/frontend/src/components/nodes/OutputNode.tsx
@@ -9,6 +9,7 @@ export default function OutputNode({ data }: NodeProps<OutputNodeData>) {
     <div className="bg-white dark:bg-gray-700 border dark:border-gray-600 rounded shadow-sm px-2 py-1 text-sm dark:text-white">
       <div className="font-bold text-center">{data.title || 'Output'}</div>
       <Handle type="target" position={Position.Left} id="in" />
+      <Handle type="source" position={Position.Right} id="out" />
     </div>
   );
 }

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -8,6 +8,7 @@ import {
   useNodesState,
   useEdgesState,
   addEdge,
+  MarkerType,
   type Connection,
   type Edge,
   type Node,
@@ -30,6 +31,11 @@ const nodeTypes = {
   output: OutputNode,
   tool: ToolNode,
   condition: ConditionNode,
+};
+
+const defaultEdgeOptions = {
+  markerEnd: { type: MarkerType.ArrowClosed },
+  style: { stroke: '#ffffff' },
 };
 
 type CustomNodeData =
@@ -185,6 +191,12 @@ function FlowBuilder() {
     if (selectedNode.type === 'llm') {
       return (
         <aside className="absolute right-0 top-0 w-72 h-full bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-600 p-4 overflow-y-auto text-black dark:text-white">
+          <button
+            className="absolute top-1 right-1 text-xl text-gray-500"
+            onClick={() => setSelectedNodeId(null)}
+          >
+            &times;
+          </button>
           <h2 className="font-bold mb-2">LLM Node</h2>
           <label className="block text-sm">Title</label>
           <input
@@ -249,6 +261,12 @@ function FlowBuilder() {
       const data = selectedNode.data as InputNodeData;
       return (
         <aside className="absolute right-0 top-0 w-72 h-full bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-600 p-4 overflow-y-auto text-black dark:text-white">
+          <button
+            className="absolute top-1 right-1 text-xl text-gray-500"
+            onClick={() => setSelectedNodeId(null)}
+          >
+            &times;
+          </button>
           <h2 className="font-bold mb-2">Input Node</h2>
           <label className="block text-sm">Title</label>
           <input
@@ -270,6 +288,12 @@ function FlowBuilder() {
       const data = selectedNode.data as OutputNodeData;
       return (
         <aside className="absolute right-0 top-0 w-72 h-full bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-600 p-4 overflow-y-auto text-black dark:text-white">
+          <button
+            className="absolute top-1 right-1 text-xl text-gray-500"
+            onClick={() => setSelectedNodeId(null)}
+          >
+            &times;
+          </button>
           <h2 className="font-bold mb-2">Output Node</h2>
           <label className="block text-sm">Title</label>
           <input
@@ -284,6 +308,12 @@ function FlowBuilder() {
       const data = selectedNode.data as ToolNodeData;
       return (
         <aside className="absolute right-0 top-0 w-72 h-full bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-600 p-4 overflow-y-auto text-black dark:text-white">
+          <button
+            className="absolute top-1 right-1 text-xl text-gray-500"
+            onClick={() => setSelectedNodeId(null)}
+          >
+            &times;
+          </button>
           <h2 className="font-bold mb-2">Tool Node</h2>
           <label className="block text-sm">Title</label>
           <input
@@ -304,6 +334,12 @@ function FlowBuilder() {
       const data = selectedNode.data as ConditionNodeData;
       return (
         <aside className="absolute right-0 top-0 w-72 h-full bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-600 p-4 overflow-y-auto text-black dark:text-white">
+          <button
+            className="absolute top-1 right-1 text-xl text-gray-500"
+            onClick={() => setSelectedNodeId(null)}
+          >
+            &times;
+          </button>
           <h2 className="font-bold mb-2">Condition Node</h2>
           <label className="block text-sm">Title</label>
           <input
@@ -399,6 +435,7 @@ function FlowBuilder() {
             nodes={nodes}
             edges={edges}
             nodeTypes={nodeTypes}
+            defaultEdgeOptions={defaultEdgeOptions}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}


### PR DESCRIPTION
## Summary
- add environment-based `/api/test/{provider}` endpoint
- enhance NodeSettings with key inputs and status badges
- support connections with handles for all node components
- add edge arrows and dark colors
- close node panels via new button

## Testing
- `npm --prefix frontend run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686441b7241c8320be4258c22eead0c0