### PR TITLE
Add API test flows and UI improvements

### DIFF
--- a/backend/app/api/routes_nodes.py
+++ b/backend/app/api/routes_nodes.py
@@ -78,37 +78,64 @@ def test_node(provider: str, payload: TestPayload):
     if provider == 'gemini':
         key = payload.key or settings.GEMINI_API_KEY
         ok, msg = key_present('GEMINI_API_KEY', key)
-        return log_and_response("success" if ok else "failed", provider, msg, logs)
+        if not ok:
+            return log_and_response("failed", provider, msg, logs)
+        ok, err = check_url(
+            f"https://generativelanguage.googleapis.com/v1beta/models?key={key}"
+        )
+        return log_and_response("success" if ok else "failed", provider, err or "ok", logs)
 
     if provider == 'etherscan':
         key = payload.key or settings.ETHERSCAN_API_KEY
         ok, msg = key_present('ETHERSCAN_API_KEY', key)
-        return log_and_response("success" if ok else "failed", provider, msg, logs)
+        if not ok:
+            return log_and_response("failed", provider, msg, logs)
+        ok, err = check_url(
+            f"https://api.etherscan.io/api?module=stats&action=ethprice&apikey={key}"
+        )
+        return log_and_response("success" if ok else "failed", provider, err or "ok", logs)
 
     if provider == 'tiktok':
         key = payload.key or settings.TIKTOK_API_KEY
         ok, msg = key_present('TIKTOK_API_KEY', key)
-        return log_and_response("success" if ok else "failed", provider, msg, logs)
+        if not ok:
+            return log_and_response("failed", provider, msg, logs)
+        ok, err = check_url('https://open.tiktokapis.com/v2', headers={"Authorization": f"Bearer {key}"})
+        return log_and_response("success" if ok else "failed", provider, err or "ok", logs)
 
     if provider == 'gmail':
         key = payload.key or settings.GMAIL_API_KEY
         ok, msg = key_present('GMAIL_API_KEY', key)
-        return log_and_response("success" if ok else "failed", provider, msg, logs)
+        if not ok:
+            return log_and_response("failed", provider, msg, logs)
+        ok, err = check_url('https://gmail.googleapis.com', headers={"Authorization": f"Bearer {key}"})
+        return log_and_response("success" if ok else "failed", provider, err or "ok", logs)
 
     if provider == 'bscan':
         key = payload.key or settings.BSCAN_API_KEY
         ok, msg = key_present('BSCAN_API_KEY', key)
-        return log_and_response("success" if ok else "failed", provider, msg, logs)
+        if not ok:
+            return log_and_response("failed", provider, msg, logs)
+        ok, err = check_url(
+            f"https://api.bscscan.com/api?module=stats&action=bnbprice&apikey={key}"
+        )
+        return log_and_response("success" if ok else "failed", provider, err or "ok", logs)
 
     if provider == 'facebook':
         key = payload.key or settings.FACEBOOK_API_KEY
         ok, msg = key_present('FACEBOOK_API_KEY', key)
-        return log_and_response("success" if ok else "failed", provider, msg, logs)
+        if not ok:
+            return log_and_response("failed", provider, msg, logs)
+        ok, err = check_url('https://graph.facebook.com', headers={"Authorization": f"Bearer {key}"})
+        return log_and_response("success" if ok else "failed", provider, err or "ok", logs)
 
     if provider == 'paypal':
         key = payload.key or settings.PAYPAL_API_KEY
         ok, msg = key_present('PAYPAL_API_KEY', key)
-        return log_and_response("success" if ok else "failed", provider, msg, logs)
+        if not ok:
+            return log_and_response("failed", provider, msg, logs)
+        ok, err = check_url('https://api.paypal.com', headers={"Authorization": f"Bearer {key}"})
+        return log_and_response("success" if ok else "failed", provider, err or "ok", logs)
 
     if provider == 'binance':
         key = payload.key or settings.BINANCE_API_KEY

--- a/frontend/src/components/NodeSettings.tsx
+++ b/frontend/src/components/NodeSettings.tsx
@@ -34,6 +34,7 @@ export default function NodeSettings() {
   };
 
   const testProvider = async (prov: string) => {
+    setStatuses((s) => ({ ...s, [prov]: 'pending' }));
     try {
       const res = await fetch(`${baseUrl}/api/test/${prov}`, {
         method: 'POST',
@@ -51,6 +52,7 @@ export default function NodeSettings() {
 
   const statusColor = (status: string | undefined) => {
     if (status === 'success') return 'text-green-400';
+    if (status === 'pending') return 'text-orange-400';
     if (status === 'warning') return 'text-yellow-400';
     return 'text-red-400';
   };
@@ -71,6 +73,8 @@ export default function NodeSettings() {
                 className={`ml-2 text-xs px-2 py-0.5 rounded ${
                   statuses[p] === 'success'
                     ? 'bg-green-600'
+                    : statuses[p] === 'pending'
+                    ? 'bg-orange-600'
                     : statuses[p] === 'warning'
                     ? 'bg-yellow-600'
                     : 'bg-red-600'

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light') {
+      setTheme('light');
+    }
+  }, []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  return (
+    <button onClick={toggle} className="border px-2 py-1 rounded w-full">
+      {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+    </button>
+  );
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,8 +1,18 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import ErrorBoundary from '../components/ErrorBoundary';
+import { useEffect } from 'react';
 
 export default function App({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') || 'dark';
+    if (stored === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, []);
+
   return (
     <ErrorBoundary>
       <Component {...pageProps} />

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -2,9 +2,9 @@ import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
-    <Html className="dark">
+    <Html>
       <Head />
-      <body className="bg-gray-900 text-white cursor-default">
+      <body className="bg-white text-black dark:bg-gray-900 dark:text-white cursor-default">
         <Main />
         <NextScript />
       </body>

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import ApiConnections from '../components/ApiConnections';
 import NodeSettings from '../components/NodeSettings';
 import ApiStatus from '../components/ApiStatus';
+import ThemeToggle from '../components/ThemeToggle';
 import { useState } from 'react';
 
 export default function Settings() {
@@ -14,8 +15,9 @@ export default function Settings() {
       </Head>
       <Link href="/" className="text-blue-500">&larr; Back</Link>
       <h1 className="text-xl font-bold mb-4">Settings</h1>
-      <div className="mb-4">
+      <div className="mb-4 space-y-2">
         <ApiStatus />
+        <ThemeToggle />
       </div>
       <div className="flex">
         <aside className="w-40 mr-4 space-y-2">


### PR DESCRIPTION
## Summary
- implement provider test checks with simple API pings
- add ThemeToggle component and dark/light mode handling
- wrap node inspector in closable drawer
- show node test status including pending state

## Testing
- `python -m py_compile backend/app/api/routes_nodes.py`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ddd953a883208095336ec87e87db