### PR TITLE
Implement basic workflow builder

### DIFF
--- a/backend/app/api/routes_workflows.py
+++ b/backend/app/api/routes_workflows.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from pathlib import Path
 import json
+from uuid import uuid4
 from ..engine.runner import execute_workflow
 
 router = APIRouter()
@@ -11,32 +12,17 @@ WORKFLOW_DIR.mkdir(exist_ok=True)
 def run_workflow(graph: dict):
     return execute_workflow(graph)
 
-@router.post('/save')
-def save_workflow(payload: dict):
-    """Save a workflow graph to disk."""
-    name = payload.get("name")
-    graph = payload.get("graph")
-    if not name or not graph:
-        raise HTTPException(status_code=400, detail="Missing name or graph")
-    path = WORKFLOW_DIR / f"{name}.json"
+@router.post('')
+def create_workflow(graph: dict):
+    """Save a workflow graph and return its id."""
+    wf_id = str(uuid4())
+    path = WORKFLOW_DIR / f"{wf_id}.json"
     path.write_text(json.dumps(graph, indent=2))
-    return {"status": "saved", "name": name}
+    return {"id": wf_id}
 
-
-@router.post('/load')
-def load_workflow(payload: dict):
-    """Load a workflow graph from disk."""
-    name = payload.get("name")
-    if not name:
-        raise HTTPException(status_code=400, detail="Missing name")
-    path = WORKFLOW_DIR / f"{name}.json"
-    if not path.exists():
-        raise HTTPException(status_code=404, detail="Workflow not found")
-    return json.loads(path.read_text())
-
-@router.get('/{name}')
-def get_workflow(name: str):
-    path = WORKFLOW_DIR / f"{name}.json"
+@router.get('/{workflow_id}')
+def get_workflow(workflow_id: str):
+    path = WORKFLOW_DIR / f"{workflow_id}.json"
     if not path.exists():
         raise HTTPException(status_code=404, detail="Workflow not found")
     return json.loads(path.read_text())

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,12 +10,15 @@
   "dependencies": {
     "@headlessui/react": "^1.7.19",
     "@radix-ui/react-tooltip": "^2.1.0",
+    "@radix-ui/react-dialog": "^2.0.1",
     "downloadjs": "1.4.7",
     "next": "^14.2.30",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "reactflow": "^11.11.4",
-    "zustand": "4.4.1"
+    "react-flow-renderer": "^11.8.7",
+    "zustand": "4.4.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/node": "24.0.8",

--- a/frontend/src/components/nodes/ActionNode.tsx
+++ b/frontend/src/components/nodes/ActionNode.tsx
@@ -1,0 +1,11 @@
+import { Handle, NodeProps, Position } from 'reactflow';
+
+export default function ActionNode({ data }: NodeProps<{ label: string }>) {
+  return (
+    <div className="bg-white dark:bg-gray-700 border dark:border-gray-600 rounded shadow-sm px-2 py-1 text-sm dark:text-white">
+      <div className="font-bold text-center">{data.label || 'Action'}</div>
+      <Handle type="target" position={Position.Left} id="in" />
+      <Handle type="source" position={Position.Right} id="out" />
+    </div>
+  );
+}

--- a/frontend/src/components/nodes/TriggerNode.tsx
+++ b/frontend/src/components/nodes/TriggerNode.tsx
@@ -1,0 +1,10 @@
+import { Handle, NodeProps, Position } from 'reactflow';
+
+export default function TriggerNode({ data }: NodeProps<{ label: string }>) {
+  return (
+    <div className="bg-white dark:bg-gray-700 border dark:border-gray-600 rounded shadow-sm px-2 py-1 text-sm dark:text-white">
+      <div className="font-bold text-center">{data.label || 'Trigger'}</div>
+      <Handle type="source" position={Position.Right} id="out" />
+    </div>
+  );
+}

--- a/frontend/src/pages/builder.tsx
+++ b/frontend/src/pages/builder.tsx
@@ -1,0 +1,146 @@
+import Head from 'next/head';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import ReactFlow, {
+  ReactFlowProvider,
+  useReactFlow,
+  Connection,
+  addEdge,
+  useNodesState,
+  useEdgesState,
+  Node,
+  Edge,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import { v4 as uuidv4 } from 'uuid';
+import TriggerNode from '../components/nodes/TriggerNode';
+import ActionNode from '../components/nodes/ActionNode';
+import ConditionNode from '../components/nodes/ConditionNode';
+import { useWorkflowStore } from '../state/workflowStore';
+
+const nodeTypes = {
+  trigger: TriggerNode,
+  action: ActionNode,
+  condition: ConditionNode,
+};
+
+function BuilderInner() {
+  const reactFlowWrapper = useRef<HTMLDivElement>(null);
+  const { project } = useReactFlow();
+  const { nodes: storeNodes, edges: storeEdges, setNodes: setStoreNodes, setEdges: setStoreEdges } = useWorkflowStore();
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node[]>(storeNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge[]>(storeEdges);
+  const [workflowId, setWorkflowId] = useState('');
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  useEffect(() => setNodes(storeNodes), [storeNodes]);
+  useEffect(() => setEdges(storeEdges), [storeEdges]);
+  useEffect(() => setStoreNodes(nodes), [nodes, setStoreNodes]);
+  useEffect(() => setStoreEdges(edges), [edges, setStoreEdges]);
+
+  const onConnect = useCallback((params: Connection) => setEdges((eds) => addEdge(params, eds)), []);
+
+  const onDragStart = (event: React.DragEvent, type: string) => {
+    event.dataTransfer.setData('application/reactflow', type);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+      const type = event.dataTransfer.getData('application/reactflow');
+      if (!reactFlowWrapper.current || !type) return;
+      const bounds = reactFlowWrapper.current.getBoundingClientRect();
+      const position = project({ x: event.clientX - bounds.left, y: event.clientY - bounds.top });
+      const newNode: Node = {
+        id: uuidv4(),
+        type,
+        position,
+        data: { label: type.charAt(0).toUpperCase() + type.slice(1) },
+      };
+      setNodes((nds) => nds.concat(newNode));
+    },
+    [project, setNodes],
+  );
+
+  const saveWorkflow = async () => {
+    const res = await fetch(`${baseUrl}/api/workflows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nodes, edges }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setWorkflowId(data.id);
+    }
+  };
+
+  const openWorkflow = async () => {
+    if (!workflowId) return;
+    const res = await fetch(`${baseUrl}/api/workflows/${workflowId}`);
+    if (res.ok) {
+      const data = await res.json();
+      setNodes(data.nodes || []);
+      setEdges(data.edges || []);
+    }
+  };
+
+  return (
+    <div className="flex h-screen">
+      <aside className="w-40 bg-gray-100 dark:bg-gray-900 p-2 space-y-2 text-black dark:text-white">
+        {['trigger', 'action', 'condition'].map((t) => (
+          <div
+            key={t}
+            className="p-2 bg-white dark:bg-gray-700 border rounded dark:border-gray-600 cursor-grab"
+            draggable
+            onDragStart={(e) => onDragStart(e, t)}
+          >
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </div>
+        ))}
+        <button onClick={saveWorkflow} className="w-full bg-blue-600 text-white px-2 py-1 rounded">
+          Save
+        </button>
+        <div className="flex space-x-1">
+          <input
+            value={workflowId}
+            onChange={(e) => setWorkflowId(e.target.value)}
+            className="flex-1 px-1 text-black"
+            placeholder="id"
+          />
+          <button onClick={openWorkflow} className="bg-blue-600 text-white px-2 rounded">
+            Open
+          </button>
+        </div>
+      </aside>
+      <main className="flex-1" ref={reactFlowWrapper}>
+        <ReactFlow
+          nodeTypes={nodeTypes}
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onDrop={onDrop}
+          onDragOver={onDragOver}
+          className="h-full"
+        />
+      </main>
+    </div>
+  );
+}
+
+export default function BuilderPage() {
+  return (
+    <ReactFlowProvider>
+      <Head>
+        <title>Workflow Builder</title>
+      </Head>
+      <BuilderInner />
+    </ReactFlowProvider>
+  );
+}

--- a/frontend/src/state/workflowStore.ts
+++ b/frontend/src/state/workflowStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+import { Node, Edge } from 'reactflow';
+
+interface WorkflowState {
+  nodes: Node[];
+  edges: Edge[];
+  setNodes: (nodes: Node[]) => void;
+  setEdges: (edges: Edge[]) => void;
+}
+
+export const useWorkflowStore = create<WorkflowState>((set) => ({
+  nodes: [],
+  edges: [],
+  setNodes: (nodes) => set({ nodes }),
+  setEdges: (edges) => set({ edges }),
+}));


### PR DESCRIPTION
## Summary
- add builder UI and Zustand store
- provide Trigger/Action/Condition node stubs
- store workflows via FastAPI routes
- add new client dependencies
- keep workflows folder in repo

## Testing
- `npm run lint` *(fails: next not installed)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865b67bbae88320a8ae1040b46341ae