### PR TITLE
Fix nodes page and workflow persistence

### DIFF
--- a/backend/tests/test_nodes.py
+++ b/backend/tests/test_nodes.py
@@ -12,12 +12,24 @@ def test_list_and_retest(tmp_path, monkeypatch):
     with TestClient(app) as client:
         resp = client.get("/api/nodes")
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert len(resp.json()) > 0
         resp2 = client.post("/api/nodes/openai/retest")
         assert resp2.status_code == 200
         data = resp2.json()
         assert data["provider"] == "openai"
         resp3 = client.get("/api/nodes")
         assert resp3.status_code == 200
-        assert len(resp3.json()) == 1
+        data_list = resp3.json()
+        assert any(i["provider"] == "openai" and i["status"] == "ok" for i in data_list)
+
+
+def test_nodes_non_empty(tmp_path, monkeypatch):
+    engine = create_engine(f"sqlite:///{tmp_path}/test2.db")
+    monkeypatch.setattr(routes_nodes, "engine", engine)
+    SQLModel.metadata.create_all(engine)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/nodes")
+        assert resp.status_code == 200
+        assert len(resp.json()) > 0
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "lint": "next lint",
     "lint:ci": "next lint --max-warnings=0",
     "test": "jest",
+    "predev": "rimraf .next/cache",
     "e2e": "npm-run-all -p dev:start e2e:test",
     "dev:start": "next dev",
     "e2e:test": "playwright test --project=chromium",
@@ -47,6 +48,7 @@
     "tailwindcss": "3.3.5",
     "typescript": "5.2.2",
     "@types/uuid": "^9.0.2",
-    "playwright": "^1.46.0"
+    "playwright": "^1.46.0",
+    "rimraf": "^5.0.5"
   }
 }

--- a/frontend/public/cursors/cursor-dark.svg
+++ b/frontend/public/cursors/cursor-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="24" viewBox="0 0 16 24" fill="black">
+  <path d="M0 0 L0 24 L6 18 L10 24 L12 23 L8 16 L15 16 Z"/>
+</svg>

--- a/frontend/public/cursors/cursor-light.svg
+++ b/frontend/public/cursors/cursor-light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="24" viewBox="0 0 16 24" fill="white">
+  <path d="M0 0 L0 24 L6 18 L10 24 L12 23 L8 16 L15 16 Z"/>
+</svg>

--- a/frontend/src/components/NodeRow.tsx
+++ b/frontend/src/components/NodeRow.tsx
@@ -1,9 +1,4 @@
-interface NodeInfo {
-  provider: string;
-  status: string;
-  last_checked?: string | null;
-  last_error?: string | null;
-}
+import type { NodeInfo } from '../hooks/useNodes';
 
 interface NodeRowProps {
   item: NodeInfo;
@@ -13,17 +8,17 @@ interface NodeRowProps {
 }
 
 export default function NodeRow({ item, onClick, onRetest, loading }: NodeRowProps) {
-  const color =
-    item.status === 'ok'
-      ? 'bg-green-500'
-      : item.status === 'warning'
-      ? 'bg-yellow-500'
-      : 'bg-red-500';
+  const icon = item.status === 'ok' ? '✓' : '✕';
+  const color = item.status === 'ok' ? 'bg-green-500' : 'bg-red-500';
   return (
     <tr onClick={onClick} data-testid="node-row" className="cursor-pointer">
       <td className="p-2 border capitalize">{item.provider}</td>
       <td className="p-2 border">
-        <span className={`inline-block h-2 w-2 rounded-full ${color}`} />
+        <span
+          className={`px-2 rounded-full text-white text-xs ${color}`}
+        >
+          {icon}
+        </span>
       </td>
       <td className="p-2 border">{item.last_checked || '-'}</td>
       <td className="p-2 border text-xs">{item.last_error || '-'}</td>

--- a/frontend/src/components/NodeSettings.tsx
+++ b/frontend/src/components/NodeSettings.tsx
@@ -1,21 +1,13 @@
-import useSWR from 'swr';
 import { useState } from 'react';
 import ProviderTestModal from './ProviderTestModal';
 import NodeRow from './NodeRow';
-
-interface NodeInfo {
-  provider: string;
-  status: string;
-  last_checked?: string | null;
-  last_error?: string | null;
-}
+import { useNodes, NodeInfo } from '../hooks/useNodes';
 
 export default function NodeSettings() {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-  const fetcher = (url: string) => fetch(url).then((r) => r.json());
-  const { data: rows = [], mutate } = useSWR<NodeInfo[]>(`${baseUrl}/api/nodes`, fetcher);
+  const { nodes: rows, mutate } = useNodes();
   const [selected, setSelected] = useState<NodeInfo | null>(null);
 
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
   const retest = async (provider: string) => {
     await fetch(`${baseUrl}/api/nodes/${provider}/retest`, { method: 'POST' });
     mutate();

--- a/frontend/src/hooks/useNodes.ts
+++ b/frontend/src/hooks/useNodes.ts
@@ -1,0 +1,16 @@
+import useSWR from 'swr';
+
+export interface NodeInfo {
+  provider: string;
+  status: string;
+  last_checked?: string | null;
+  last_error?: string | null;
+}
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export function useNodes() {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  const { data, error, mutate } = useSWR<NodeInfo[]>(`${baseUrl}/api/providers`, fetcher);
+  return { nodes: data || [], loading: !error && !data, error, mutate };
+}

--- a/frontend/src/hooks/useWorkflowList.ts
+++ b/frontend/src/hooks/useWorkflowList.ts
@@ -1,0 +1,15 @@
+import useSWR from 'swr';
+import { useWorkflowListStore, WorkflowMeta } from '../state/workflowListStore';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+export function useWorkflowList() {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  const { setList } = useWorkflowListStore();
+  const { data, error, mutate } = useSWR<WorkflowMeta[]>(
+    `${baseUrl}/api/workflows`,
+    fetcher,
+    { onSuccess: (d) => setList(d) }
+  );
+  return { workflows: data || [], loading: !error && !data, error, mutate };
+}

--- a/frontend/src/state/workflowListStore.ts
+++ b/frontend/src/state/workflowListStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+export interface WorkflowMeta {
+  id: number;
+  name: string;
+}
+
+interface WorkflowListState {
+  list: WorkflowMeta[];
+  setList: (items: WorkflowMeta[]) => void;
+  add: (item: WorkflowMeta) => void;
+}
+
+export const useWorkflowListStore = create<WorkflowListState>((set) => ({
+  list: [],
+  setList: (items) => set({ list: items }),
+  add: (item) => set((state) => ({ list: [...state.list, item] })),
+}));

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -3,7 +3,11 @@
 @tailwind utilities;
 
 body {
-  cursor: default;
+  cursor: url('/cursors/cursor-dark.svg'), default;
+}
+
+html.dark body {
+  cursor: url('/cursors/cursor-light.svg'), default;
 }
 
 input,

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "pixelmind-labs-root",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 --app-dir backend\" \"npm run dev --prefix frontend\""
+    "dev": "npm-run-all -p backend frontend",
+    "backend": "uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 --app-dir backend",
+    "frontend": "npm run dev --prefix frontend",
+    "e2e": "npm-run-all -p backend frontend:e2e",
+    "frontend:e2e": "npm run e2e --prefix frontend"
   },
   "devDependencies": {
-    "concurrently": "^8.2.0"
+    "npm-run-all": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- seed known providers when listing nodes and expose `/providers`
- tweak NodeRow style and fetch nodes via custom hook
- clear Next.js cache before dev and set themed cursors
- manage workflows in Zustand and dropdown selection
- add cross-platform npm scripts
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b2f5b40483209671653119b764e2