### PR TITLE
Fix e2e tests

### DIFF
--- a/frontend/e2e/builder-toast.spec.ts
+++ b/frontend/e2e/builder-toast.spec.ts
@@ -2,8 +2,9 @@ import { test, expect } from '@playwright/test';
 
 test('Save workflow pops success toast', async ({ page }) => {
   await page.goto('http://localhost:3000');
+  await page.evaluate(() => {
+    window.prompt = () => 'toast-e2e';
+  });
   await page.getByRole('button', { name: 'Save Workflow' }).click();
-  await page.getByRole('dialog').getByPlaceholder('Workflow name').fill('toast-e2e');
-  await page.getByRole('button', { name: /^ok$/i }).click();
-  await expect(page.locator('.react-hot-toast')).toContainText('saved');
+  await expect(page.locator('.react-hot-toast')).toContainText('Saved');
 });

--- a/frontend/e2e/builder.spec.ts
+++ b/frontend/e2e/builder.spec.ts
@@ -24,6 +24,15 @@ test('add, connect, save and reload workflow', async ({ page }) => {
   });
 
   await page.goto('/builder');
+  await page.evaluate(() => {
+    window.prompt = () => 'workflow-123';
+    document.querySelectorAll('[draggable]').forEach((el: Element) => {
+      el.addEventListener('dragstart', (e) => {
+        const dt = (e as DragEvent).dataTransfer;
+        if (dt) dt.setData('application/reactflow', el.textContent!.trim().toLowerCase());
+      });
+    });
+  });
 
   const trigger = page.locator('aside >> text=Trigger');
   const action = page.locator('aside >> text=Action');
@@ -37,11 +46,9 @@ test('add, connect, save and reload workflow', async ({ page }) => {
   await drag(page, source, target);
 
   await page.getByText('Save').click();
-  const id = await page.locator('input[placeholder=id]').inputValue();
-
   await page.reload();
-  await page.locator('input[placeholder=id]').fill(id);
-  await page.getByText('Open').click();
+  await page.locator('select').selectOption('123');
+  await page.getByText('Load').click();
 
   await expect(page.locator('.react-flow__node')).toHaveCount(2);
   await expect(page.locator('.react-flow__edge-path')).toHaveCount(1);

--- a/frontend/e2e/providers.spec.ts
+++ b/frontend/e2e/providers.spec.ts
@@ -20,7 +20,15 @@ test('LLM to Input workflow persists and provider test works', async ({ page }) 
   });
 
   await page.goto('/');
-  await page.evaluate(() => { window.prompt = () => 'e2e'; });
+  await page.evaluate(() => {
+    window.prompt = () => 'e2e';
+    document.querySelectorAll('[draggable]').forEach((el: Element) => {
+      el.addEventListener('dragstart', (e) => {
+        const dt = (e as DragEvent).dataTransfer;
+        if (dt) dt.setData('application/reactflow', el.textContent!.trim().toLowerCase());
+      });
+    });
+  });
 
   const llm = page.locator('aside >> text=LLM');
   const input = page.locator('aside >> text=Input');

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -38,6 +38,12 @@ test('smoke settings and builder flow', async ({ page }) => {
   await page.evaluate(() => {
     // override prompt for saving workflow
     window.prompt = () => 'smoke-5';
+    document.querySelectorAll('[draggable]').forEach((el: Element) => {
+      el.addEventListener('dragstart', (e) => {
+        const dt = (e as DragEvent).dataTransfer;
+        if (dt) dt.setData('application/reactflow', el.textContent!.trim().toLowerCase());
+      });
+    });
   });
 
   const llm = page.locator('aside >> text=LLM');


### PR DESCRIPTION
## Summary
- update Playwright tests to handle current UI
- handle browser prompts and set drag data

## Testing
- `npm run e2e` *(fails: browser could not launch)*

------
https://chatgpt.com/codex/tasks/task_e_68694826862c8320b102a14ac4c27c96