### PR TITLE
Improve Playwright e2e test stability

### DIFF
--- a/frontend/e2e/builder-toast.spec.ts
+++ b/frontend/e2e/builder-toast.spec.ts
@@ -1,10 +1,20 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('Save workflow pops success toast', async ({ page }) => {
-  await page.goto('http://localhost:3000');
-  await page.evaluate(() => {
-    window.prompt = () => 'toast-e2e';
+test("Save workflow pops success toast", async ({ page }) => {
+  await page.route("**/api/workflows/save", async (route) => {
+    await route.fulfill({ status: 200, body: JSON.stringify({ id: "toast" }) });
   });
-  await page.getByRole('button', { name: 'Save Workflow' }).click();
-  await expect(page.locator('.react-hot-toast')).toContainText('Saved');
+  await page.route("**/api/workflows/list", (route) =>
+    route.fulfill({ status: 200, body: "[]" }),
+  );
+
+  await page.goto("http://localhost:3000");
+  await page.evaluate(() => {
+    window.prompt = () => "toast-e2e";
+  });
+
+  await page.getByRole("button", { name: "Save Workflow" }).click();
+  await expect(page.locator(".react-hot-toast")).toContainText("Saved", {
+    timeout: 10000,
+  });
 });

--- a/frontend/e2e/builder.spec.ts
+++ b/frontend/e2e/builder.spec.ts
@@ -1,55 +1,72 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
 const drag = async (page, source, target, pos) => {
   const box = await source.boundingBox();
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
   await page.mouse.down();
   const tbox = await target.boundingBox();
-  await page.mouse.move(tbox.x + (pos?.x || tbox.width / 2), tbox.y + (pos?.y || tbox.height / 2));
+  await page.mouse.move(
+    tbox.x + (pos?.x || tbox.width / 2),
+    tbox.y + (pos?.y || tbox.height / 2),
+  );
   await page.mouse.up();
 };
 
-test('add, connect, save and reload workflow', async ({ page }) => {
+test("add, connect, save and reload workflow", async ({ page }) => {
   let saved: any = null;
-  await page.route('**/api/workflows', async (route, request) => {
-    if (request.method() === 'POST') {
-      saved = await request.postDataJSON();
-      await route.fulfill({ status: 200, body: JSON.stringify({ id: '123' }) });
-    } else {
-      await route.fallback();
-    }
+  await page.route("**/api/workflows/save", async (route, request) => {
+    saved = await request.postDataJSON();
+    await route.fulfill({ status: 200, body: JSON.stringify({ id: "123" }) });
   });
-  await page.route('**/api/workflows/123', async (route) => {
+  await page.route("**/api/workflows/123", async (route) => {
     await route.fulfill({ status: 200, body: JSON.stringify(saved) });
   });
+  await page.route("**/api/workflows/list", async (route) => {
+    await route.fulfill({
+      status: 200,
+      body: JSON.stringify([{ id: "123", name: "workflow-123" }]),
+    });
+  });
 
-  await page.goto('/builder');
+  await page.goto("/builder");
   await page.evaluate(() => {
-    window.prompt = () => 'workflow-123';
-    document.querySelectorAll('[draggable]').forEach((el: Element) => {
-      el.addEventListener('dragstart', (e) => {
+    window.prompt = () => "workflow-123";
+    document.querySelectorAll("[draggable]").forEach((el: Element) => {
+      el.addEventListener("dragstart", (e) => {
         const dt = (e as DragEvent).dataTransfer;
-        if (dt) dt.setData('application/reactflow', el.textContent!.trim().toLowerCase());
+        if (dt)
+          dt.setData(
+            "application/reactflow",
+            el.textContent!.trim().toLowerCase(),
+          );
       });
     });
   });
 
-  const trigger = page.locator('aside >> text=Trigger');
-  const action = page.locator('aside >> text=Action');
-  const canvas = page.locator('main');
+  const trigger = page.locator("aside >> text=Trigger");
+  const action = page.locator("aside >> text=Action");
+  const canvas = page.locator("main");
+
+  await expect(trigger).toBeVisible();
+  await expect(action).toBeVisible();
 
   await trigger.dragTo(canvas, { targetPosition: { x: 200, y: 200 } });
   await action.dragTo(canvas, { targetPosition: { x: 400, y: 200 } });
 
-  const source = page.locator('.react-flow__node-trigger .react-flow__handle.source');
-  const target = page.locator('.react-flow__node-action .react-flow__handle.target');
+  const source = page.locator(
+    ".react-flow__node-trigger .react-flow__handle.source",
+  );
+  const target = page.locator(
+    ".react-flow__node-action .react-flow__handle.target",
+  );
   await drag(page, source, target);
 
-  await page.getByText('Save').click();
+  await page.getByText("Save").click();
   await page.reload();
-  await page.locator('select').selectOption('123');
-  await page.getByText('Load').click();
+  await page.waitForSelector("select");
+  await page.locator("select").selectOption("123");
+  await page.getByText("Load").click();
 
-  await expect(page.locator('.react-flow__node')).toHaveCount(2);
-  await expect(page.locator('.react-flow__edge-path')).toHaveCount(1);
+  await expect(page.locator(".react-flow__node")).toHaveCount(2);
+  await expect(page.locator(".react-flow__edge-path")).toHaveCount(1);
 });

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
 const drag = async (page, source, target) => {
   const box = await source.boundingBox();
@@ -9,63 +9,88 @@ const drag = async (page, source, target) => {
   await page.mouse.up();
 };
 
-test('smoke settings and builder flow', async ({ page }) => {
-  await page.route('**/api/providers', async (route) => {
+test("smoke settings and builder flow", async ({ page }) => {
+  await page.route("**/api/providers", async (route) => {
     await route.fulfill({
       status: 200,
-      body: JSON.stringify([{ provider: 'Google', status: 'ok' }]),
+      body: JSON.stringify([{ provider: "Google", status: "ok" }]),
     });
   });
-  await page.route('**/api/providers/Google/test', async (route) => {
-    await route.fulfill({ status: 200, body: JSON.stringify({ success: true }) });
+  await page.route("**/api/providers/Google/test", async (route) => {
+    await route.fulfill({
+      status: 200,
+      body: JSON.stringify({ success: true }),
+    });
   });
 
-  await page.goto('/settings');
-  await expect(page.locator('tbody tr')).toContainText('Google');
-  await page.getByRole('button', { name: 'Test' }).click();
-  await expect(page.locator('pre')).toContainText('"success": true');
+  await page.goto("/settings");
+  await expect(page.locator("tbody tr")).toContainText("Google");
+  await page.getByRole("button", { name: "Test" }).click();
+  await expect(page.locator("pre")).toContainText('"success": true');
 
   let saved: any = null;
-  await page.route('**/api/workflows/save', async (route, request) => {
+  await page.route("**/api/workflows/save", async (route, request) => {
     saved = await request.postDataJSON();
-    await route.fulfill({ status: 200, body: JSON.stringify({ id: '5' }) });
+    await route.fulfill({ status: 200, body: JSON.stringify({ id: "5" }) });
   });
-  await page.route('**/api/workflows/5', async (route) => {
+  await page.route("**/api/workflows/5", async (route) => {
     await route.fulfill({ status: 200, body: JSON.stringify(saved) });
   });
+  await page.route("**/api/workflows/list", async (route) => {
+    await route.fulfill({
+      status: 200,
+      body: JSON.stringify([{ id: "5", name: "smoke-5" }]),
+    });
+  });
 
-  await page.goto('/?wid=new');
+  await page.goto("/?wid=new");
+  await page.waitForLoadState("networkidle");
   await page.evaluate(() => {
     // override prompt for saving workflow
-    window.prompt = () => 'smoke-5';
-    document.querySelectorAll('[draggable]').forEach((el: Element) => {
-      el.addEventListener('dragstart', (e) => {
+    window.prompt = () => "smoke-5";
+    document.querySelectorAll("[draggable]").forEach((el: Element) => {
+      el.addEventListener("dragstart", (e) => {
         const dt = (e as DragEvent).dataTransfer;
-        if (dt) dt.setData('application/reactflow', el.textContent!.trim().toLowerCase());
+        if (dt)
+          dt.setData(
+            "application/reactflow",
+            el.textContent!.trim().toLowerCase(),
+          );
       });
     });
   });
 
-  const llm = page.locator('aside >> text=LLM');
-  const input = page.locator('aside >> text=Input');
-  const output = page.locator('aside >> text=Output');
-  const canvas = page.locator('main');
+  const llm = page.locator("aside >> text=LLM");
+  const input = page.locator("aside >> text=Input");
+  const output = page.locator("aside >> text=Output");
+  const canvas = page.locator("main");
+
+  await expect(llm).toBeVisible();
+  await expect(input).toBeVisible();
+  await expect(output).toBeVisible();
 
   await llm.dragTo(canvas, { targetPosition: { x: 200, y: 200 } });
   await input.dragTo(canvas, { targetPosition: { x: 400, y: 200 } });
   await output.dragTo(canvas, { targetPosition: { x: 600, y: 200 } });
 
-  const src1 = page.locator('.react-flow__node-llm .react-flow__handle.source');
-  const tgt1 = page.locator('.react-flow__node-input .react-flow__handle.target');
-  const src2 = page.locator('.react-flow__node-input .react-flow__handle.source');
-  const tgt2 = page.locator('.react-flow__node-output .react-flow__handle.target');
+  const src1 = page.locator(".react-flow__node-llm .react-flow__handle.source");
+  const tgt1 = page.locator(
+    ".react-flow__node-input .react-flow__handle.target",
+  );
+  const src2 = page.locator(
+    ".react-flow__node-input .react-flow__handle.source",
+  );
+  const tgt2 = page.locator(
+    ".react-flow__node-output .react-flow__handle.target",
+  );
 
   await drag(page, src1, tgt1);
   await drag(page, src2, tgt2);
 
-  await page.getByRole('button', { name: 'Save Workflow' }).click();
-  await expect(page.locator('.react-hot-toast')).toHaveCount(1);
+  await page.getByRole("button", { name: "Save Workflow" }).click();
+  await expect(page.locator(".react-hot-toast")).toHaveCount(1);
 
   await page.reload();
-  await expect(page.locator('.react-flow__node')).toHaveCount(3);
+  await page.waitForLoadState("networkidle");
+  await expect(page.locator(".react-flow__node")).toHaveCount(3);
 });


### PR DESCRIPTION
## Summary
- stub API endpoints in Playwright tests
- wait for pages to load before interacting
- check UI visibility before dragging nodes

## Testing
- `npm run lint:ci --prefix frontend`
- `npm run e2e` *(fails: locator boundingBox timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68694d0a2dec832080043a8cee9f5080